### PR TITLE
Changed VideoCapture(-1) to VideoCapture(0)

### DIFF
--- a/retico_vision/vision.py
+++ b/retico_vision/vision.py
@@ -243,7 +243,7 @@ class WebcamModule(retico_core.AbstractProducingModule):
         self.width = width
         self.height = height
         self.rate = rate
-        self.cap = cv2.VideoCapture(-1)
+        self.cap = cv2.VideoCapture(0)
 
         self.setup()
 


### PR DESCRIPTION
Tested on different PCs, -1 as value parameter could look for a ready but not working camera. 0 value always uses the main one, seems to work bettter.